### PR TITLE
fix: typo

### DIFF
--- a/Marshell/VC/RadioVC.swift
+++ b/Marshell/VC/RadioVC.swift
@@ -108,7 +108,7 @@ class RadioVC: NSViewController {
         menu.addItem(withTitle: "Edit This Source", action: #selector(edit), keyEquivalent: "")
         
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(withTitle: "Raload", action: #selector(reloadWebView), keyEquivalent: "")
+        menu.addItem(withTitle: "Reload", action: #selector(reloadWebView), keyEquivalent: "")
         menu.addItem(withTitle: "Open in Browser", action: #selector(openInBrowser), keyEquivalent: "")
         menu.addItem(withTitle: "Quit App", action: #selector(quitApp), keyEquivalent: "")
         


### PR DESCRIPTION
## Description

There is a typo in the settings menu. 

## Changes

Changed the word "Raload" to "Reload"

- [x] Bug fix (non-breaking change which fixes an issue)
